### PR TITLE
Latest changes from the upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: bash
 services: docker
 
 env:
-  - VARIANT=trusty
+  - VARIANT=xenial
 
 install:
   - git clone https://github.com/docker-library/official-images.git official-images

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The style of the repo follows that of the Linux kernel, in particular:
 * More details in the body
 * Match surrounding coding style (line wrapping, spaces, etc)
 
-More details in the [SubmittingPatches](https://www.kernel.org/doc/Documentation/SubmittingPatches) document included with the Linux kernel.  In particular the following sections:
+More details in the [SubmittingPatches](https://www.kernel.org/doc/html/latest/process/submitting-patches.html) document included with the Linux kernel.  In particular the following sections:
 
 * `2) Describe your changes`
 * `3) Separate your changes`

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,31 +4,43 @@ MAINTAINER Kyle Manna <kyle@kylemanna.com>
 ARG USER_ID
 ARG GROUP_ID
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8842ce5e && \
-    echo "deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main" > /etc/apt/sources.list.d/bitcoin.list
-
-RUN apt-get update && \
-    apt-get install -y bitcoind && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 ENV HOME /bitcoin
 
 # add user with specified (or default) user/group ids
 ENV USER_ID ${USER_ID:-1000}
 ENV GROUP_ID ${GROUP_ID:-1000}
-RUN groupadd -g ${GROUP_ID} bitcoin
-RUN useradd -u ${USER_ID} -g bitcoin -s /bin/bash -m -d /bitcoin bitcoin
 
-RUN chown bitcoin:bitcoin -R /bitcoin
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -g ${GROUP_ID} bitcoin \
+	&& useradd -u ${USER_ID} -g bitcoin -s /bin/bash -m -d /bitcoin bitcoin
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8842ce5e && \
+    echo "deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main" > /etc/apt/sources.list.d/bitcoin.list
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		bitcoind \
+	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& apt-get update && apt-get install -y --no-install-recommends \
+		ca-certificates \
+		wget \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true \
+	&& apt-get purge -y \
+		ca-certificates \
+		wget \
+	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD ./bin /usr/local/bin
-RUN chmod a+x /usr/local/bin/*
-
-# For some reason, docker.io (0.9.1~dfsg1-2) pkg in Ubuntu 14.04 has permission
-# denied issues when executing /bin/bash from trusted builds.  Building locally
-# works fine (strange).  Using the upstream docker (0.11.1) pkg from
-# http://get.docker.io/ubuntu works fine also and seems simpler.
-USER bitcoin
 
 VOLUME ["/bitcoin"]
 
@@ -36,5 +48,7 @@ EXPOSE 8332 8333 18332 18333
 
 WORKDIR /bitcoin
 
-CMD ["btc_oneshot"]
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
 
+CMD ["btc_oneshot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV GROUP_ID ${GROUP_ID:-1000}
 RUN groupadd -g ${GROUP_ID} bitcoin \
 	&& useradd -u ${USER_ID} -g bitcoin -s /bin/bash -m -d /bitcoin bitcoin
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8842ce5e && \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C70EF1F0305A1ADB9986DBD8D46F45428842CE5E && \
     echo "deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main" > /etc/apt/sources.list.d/bitcoin.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:14.04
+FROM ubuntu:xenial
 MAINTAINER Kyle Manna <kyle@kylemanna.com>
 
 ARG USER_ID
 ARG GROUP_ID
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8842ce5e && \
-    echo "deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu trusty main" > /etc/apt/sources.list.d/bitcoin.list
+    echo "deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main" > /etc/apt/sources.list.d/bitcoin.list
 
 RUN apt-get update && \
     apt-get install -y bitcoind && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update \
         gnupg \
     && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ARG VERSION=0.20.1
+ARG VERSION=0.21.0
 ARG ARCH=x86_64
 ARG BITCOIN_CORE_SIGNATURE=01EA5486DE18A882D4C2684590C8019E36C2E964
 
@@ -28,7 +28,7 @@ RUN cd /tmp \
     && gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys ${BITCOIN_CORE_SIGNATURE} \
     && gpg --verify SHA256SUMS.asc \
     && grep bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz SHA256SUMS.asc > SHA25SUM \
-    && wget https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz \
+    && wget https://bitcoincore.org/bin/bitcoin-core-${VERSION}/bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz \
     && sha256sum -c SHA25SUM \
     && tar -xzvf bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz -C /opt \
     && ln -sv bitcoin-${VERSION} /opt/bitcoin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,53 @@
-FROM ubuntu:xenial
-MAINTAINER Kyle Manna <kyle@kylemanna.com>
+# Smallest base image, latests stable image
+# Alpine would be nice, but it's linked again musl and breaks the bitcoin core download binary
+#FROM alpine:latest
+FROM ubuntu:latest
 
-ARG USER_ID
-ARG GROUP_ID
+LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 
-ENV HOME /bitcoin
-
-# add user with specified (or default) user/group ids
-ENV USER_ID ${USER_ID:-1000}
-ENV GROUP_ID ${GROUP_ID:-1000}
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -g ${GROUP_ID} bitcoin \
-	&& useradd -u ${USER_ID} -g bitcoin -s /bin/bash -m -d /bitcoin bitcoin
-
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C70EF1F0305A1ADB9986DBD8D46F45428842CE5E && \
-    echo "deb http://ppa.launchpad.net/bitcoin/bitcoin/ubuntu xenial main" > /etc/apt/sources.list.d/bitcoin.list
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		bitcoind \
-	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# grab gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
-RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends \
-		ca-certificates \
-		wget \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true \
-	&& apt-get purge -y \
-		ca-certificates \
-		wget \
-	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ADD ./bin /usr/local/bin
-
+EXPOSE 8332 8333
 VOLUME ["/bitcoin"]
 
-EXPOSE 8332 8333 18332 18333
+ENTRYPOINT ["docker-entrypoint.sh"]
+ENV HOME /bitcoin
+
+ARG GROUP_ID=1000
+ARG USER_ID=1000
+RUN groupadd -g ${GROUP_ID} bitcoin \
+    && useradd -u ${USER_ID} -g bitcoin -d /bitcoin bitcoin
+
+# Testing: gosu
+#RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories \
+#    && apk add --update --no-cache gnupg gosu gcompat libgcc
+RUN apt update \
+    && apt install -y --no-install-recommends \
+        ca-certificates \
+        gosu \
+        wget \
+        gnupg \
+    && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG VERSION=0.20.1
+ARG ARCH=x86_64
+ARG BITCOIN_CORE_SIGNATURE=01EA5486DE18A882D4C2684590C8019E36C2E964
+
+# Don't use base image's bitcoin package for a few reasons:
+# 1. Would need to use ppa/latest repo for the latest release.
+# 2. Some package generates /etc/bitcoin.conf on install and that's dangerous to bake in with Docker Hub.
+# 3. Verifying pkg signature from main website should inspire confidence and reduce chance of surprises.
+# Instead fetch, verify, and extract to Docker image
+RUN cd /tmp \
+    && wget https://bitcoincore.org/bin/bitcoin-core-${VERSION}/SHA256SUMS.asc \
+    && gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys ${BITCOIN_CORE_SIGNATURE} \
+    && gpg --verify SHA256SUMS.asc \
+    && grep bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz SHA256SUMS.asc > SHA25SUM \
+    && wget https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz \
+    && sha256sum -c SHA25SUM \
+    && tar -xzvf bitcoin-${VERSION}-${ARCH}-linux-gnu.tar.gz -C /opt \
+    && ln -sv bitcoin-${VERSION} /opt/bitcoin \
+    && ln -sv /opt/bitcoin/bin/* /usr/local/bin
+
+ADD ./bin docker-entrypoint.sh /usr/local/bin/
 
 WORKDIR /bitcoin
-
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
-
 CMD ["btc_oneshot"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Requirements
 * At least 100 GB to store the block chain files (and always growing!)
 * At least 1 GB RAM + 2 GB swap file
 
-Recommended and tested on [Vultr 1024 MB RAM/320 GB disk instance @ $8/mo](http://bit.ly/vultrbitcoind).  Vultr also *accepts Bitcoin payments*!  May run on the 512 MB instance, but took *forever* (1+ week) to initialize due to swap and disk thrashing.
+Recommended and tested on unadvertised (only shown within control panel) [Vultr SATA Storage 1024 MB RAM/250 GB disk instance @ $10/mo](http://bit.ly/vultrbitcoind).  Vultr also *accepts Bitcoin payments*!
 
 
 Really Fast Quick Start

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Requirements
 ------------
 
 * Physical machine, cloud instance, or VPS that supports Docker (i.e. [Vultr](http://bit.ly/1HngXg0), [Digital Ocean](http://bit.ly/18AykdD), KVM or XEN based VMs) running Ubuntu 14.04 or later (*not OpenVZ containers!*)
-* At least 40 GB to store the block chain files
+* At least 100 GB to store the block chain files (and always growing!)
 * At least 1 GB RAM + 2 GB swap file
 
 Recommended and tested on [Vultr 1024 MB RAM/320 GB disk instance @ $8/mo](http://bit.ly/vultrbitcoind).  Vultr also *accepts Bitcoin payments*!  May run on the 512 MB instance, but took *forever* (1+ week) to initialize due to swap and disk thrashing.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Bitcoind for Docker
 [![Docker Stars](https://img.shields.io/docker/stars/kylemanna/bitcoind.svg)](https://hub.docker.com/r/kylemanna/bitcoind/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/kylemanna/bitcoind.svg)](https://hub.docker.com/r/kylemanna/bitcoind/)
 [![Build Status](https://travis-ci.org/kylemanna/docker-bitcoind.svg?branch=master)](https://travis-ci.org/kylemanna/docker-bitcoind/)
-[![ImageLayers](https://imagelayers.io/badge/kylemanna/bitcoind:latest.svg)](https://hub.docker.com/r/kylemanna/bitcoind/)
-
+[![ImageLayers](https://images.microbadger.com/badges/image/kylemanna/bitcoind.svg)](https://microbadger.com/#/images/kylemanna/bitcoind)
 
 Docker image that runs the Bitcoin bitcoind node in a container for easy deployment.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Quick Start
 1. Create a `bitcoind-data` volume to persist the bitcoind blockchain data, should exit immediately.  The `bitcoind-data` container will store the blockchain when the node container is recreated (software upgrade, reboot, etc):
 
         docker volume create --name=bitcoind-data
-        docker run -v bitcoind-data:/bitcoin --name=bitcoind-node -d \
+        docker run -v bitcoind-data:/bitcoin/.bitcoin --name=bitcoind-node -d \
             -p 8333:8333 \
             -p 127.0.0.1:8332:8332 \
             kylemanna/bitcoind

--- a/bin/btc_init
+++ b/bin/btc_init
@@ -4,21 +4,60 @@ set -ex
 
 # This shouldn't be in the Dockerfile or containers built from the same image
 # will have the same credentials.
+
+CONFIG_PATH=$HOME/.bitcoin/bitcoin.conf
+
 if [ ! -e "$HOME/.bitcoin/bitcoin.conf" ]; then
     mkdir -p $HOME/.bitcoin
+fi
 
+
+if [[ "$CONFIG_FROM_ENV" == "true" ]]; then
+    echo "Creating bitcoin.conf"
+
+    eval "VAR=\$TESTNET"
+    export TESTNET=${VAR:-"0"}
+    eval "VAR=\$REGTEST"
+    export REGTEST=${VAR:-"0"}
+
+    echo "Removing old config to generate new from env variables"
+    rm -rf $CONFIG_PATH
+    touch $CONFIG_PATH
+
+    CONF_PREFIX=""
+
+    if [[ "$TESTNET" == "1" ]]; then
+        CONF_PREFIX="test."
+        echo "testnet=1" >> $CONFIG_PATH
+    elif [[ "$REGTEST" == "1" ]]; then
+        CONF_PREFIX="regtest."
+        echo "regtest=1" >> $CONFIG_PATH
+    fi
+
+    for name in VERSION ALERTNOTIFY BLOCKNOTIFY ASSUMEVALID CONF DATADIR DBCACHE LOADBLOCK MAXORPHANTX MAXMEMPOOL MEMPOOLEXPIRY BLOCKRECONSTRUCTIONEXTRATXN PAR PID PRUNE REINDEX REINDEX SYSPERMS TXINDEX ADDNODE BANSCORE BANTIME BIND CONNECT DISCOVER DNS DNSSEED EXTERNALIP FORCEDNSSEED LISTEN LISTENONION MAXCONNECTIONS MAXRECEIVEBUFFER MAXSENDBUFFER MAXTIMEADJUSTMENT ONION ONLYNET PERMITBAREMULTISIG PEERBLOOMFILTERS PORT PROXY PROXYRANDOMIZE RPCSERIALVERSION SEEDNODE TIMEOUT TORCONTROL TORPASSWORD UPNP WHITEBIND WHITELIST WHITELISTRELAY WHITELISTFORCERELAY MAXUPLOADTARGET DISABLEWALLET KEYPOOL FALLBACKFEE MINTXFEE PAYTXFEE RESCAN SALVAGEWALLET SPENDZEROCONFCHANGE TXCONFIRMTARGET USEHD WALLETRBF UPGRADEWALLET WALLET WALLETBROADCAST WALLETNOTIFY ZAPWALLETTXES ZMQPUBHASHBLOCK ZMQPUBHASHTX ZMQPUBRAWBLOCK ZMQPUBRAWTX UACOMMENT DEBUG HELP LOGIPS LOGTIMESTAMPS MINRELAYTXFEE MAXTXFEE PRINTTOCONSOLE SHRINKDEBUGFILE BYTESPERSIGOP DATACARRIER DATACARRIERSIZE MEMPOOLREPLACEMENT BLOCKMAXWEIGHT BLOCKMAXSIZE BLOCKPRIORITYSIZE BLOCKMINTXFEE SERVER REST RPCBIND RPCCOOKIEFILE RPCUSER RPCPASSWORD RPCAUTH RPCPORT RPCALLOWIP RPCTHREADS; do
+        eval "VAR=\$${name}"
+        if [[ "$name" == "PRUNE" ]]; then
+            VAR="${VAR:-0}"
+        fi
+        if [[ "$name" == "DISABLEWALLET" ]]; then
+            VAR="${VAR:-1}"
+        fi
+        if [[ "$name" == "PRINTTOCONSOLE" ]]; then
+            VAR="${VAR:-1}"
+        fi
+        [[ -n "$VAR" ]] && echo "${CONF_PREFIX}${name,,}=${VAR}" >> $CONFIG_PATH
+    done
+elif [ ! -e "$HOME/.bitcoin/bitcoin.conf" ]; then
     echo "Creating bitcoin.conf"
 
     # Seed a random password for JSON RPC server
-    cat <<EOF > $HOME/.bitcoin/bitcoin.conf
+    cat <<EOF > $CONFIG_PATH
 disablewallet=${DISABLEWALLET:-1}
 printtoconsole=${PRINTTOCONSOLE:-1}
 rpcuser=${RPCUSER:-bitcoinrpc}
 rpcpassword=${RPCPASSWORD:-`dd if=/dev/urandom bs=33 count=1 2>/dev/null | base64`}
 EOF
-
 fi
 
-cat $HOME/.bitcoin/bitcoin.conf
-
+cat $CONFIG_PATH
 echo "Initialization completed successfully"

--- a/bin/btc_oneshot
+++ b/bin/btc_oneshot
@@ -1,14 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
 set -ex
 
 # Generate bitcoin.conf
 btc_init
 
-if [ $# -gt 0 ]; then
-    args=("$@")
-else
-    args=("-rpcallowip=::/0")
+# Default / no argument invocation listens for RPC commands and has to accept non-localhost because of
+# docker port proxying or docker private networking.
+if [ $# -eq 0 ]; then
+    set -- "-rpcbind=" "-rpcallowip=::/0"
 fi
 
-exec bitcoind "${args[@]}"
+exec bitcoind "$@"

--- a/bin/btc_oneshot
+++ b/bin/btc_oneshot
@@ -6,10 +6,11 @@ set -ex
 btc_init
 
 # Default / no argument invocation listens for RPC commands and has to accept non-localhost because of
-# Docker port proxying or Docker private networking.  Also enable IPv6 which is only useful if using host
-# networking until Docker improves its IPv6 support.
+# Docker port proxying or Docker private networking.
 if [ $# -eq 0 ]; then
-    set -- '-rpcbind=[::]:8332' '-rpcallowip=::/0' '-rpcallowip=0.0.0.0/0'
+    # If IPv6 is in the container do both:
+    #set -- '-rpcbind=[::]:8332' '-rpcallowip=::/0' '-rpcallowip=0.0.0.0/0'
+    set -- '-rpcbind=:8332' '-rpcallowip=0.0.0.0/0'
 fi
 
 exec bitcoind "$@"

--- a/bin/btc_oneshot
+++ b/bin/btc_oneshot
@@ -6,9 +6,10 @@ set -ex
 btc_init
 
 # Default / no argument invocation listens for RPC commands and has to accept non-localhost because of
-# docker port proxying or docker private networking.
+# Docker port proxying or Docker private networking.  Also enable IPv6 which is only useful if using host
+# networking until Docker improves its IPv6 support.
 if [ $# -eq 0 ]; then
-    set -- "-rpcbind=" "-rpcallowip=::/0"
+    set -- '-rpcbind=[::]:8332' '-rpcallowip=::/0' '-rpcallowip=0.0.0.0/0'
 fi
 
 exec bitcoind "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+# or first arg is `something.conf`
+if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
+	set -- btc_oneshot "$@"
+fi
+
+# allow the container to be started with `--user`
+if [ "$1" = 'btc_oneshot' -a "$(id -u)" = '0' ]; then
+	chown -R bitcoin .
+	exec gosu bitcoin "$0" "$@"
+fi
+
+exec "$@"
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,11 +7,12 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 	set -- btc_oneshot "$@"
 fi
 
-# allow the container to be started with `--user`
+# Allow the container to be started with `--user`, if running as root drop privileges
 if [ "$1" = 'btc_oneshot' -a "$(id -u)" = '0' ]; then
 	chown -R bitcoin .
 	exec gosu bitcoin "$0" "$@"
 fi
 
+# If not root (i.e. docker run --user $USER ...), then run as invoked
 exec "$@"
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,21 @@
+bitcoind config tuning
+======================
+
+You can use environment variables to customize config ([see docker run environment options](https://docs.docker.com/engine/reference/run/#/env-environment-variables)):
+
+        docker run -v bitcoind-data:/bitcoin --name=bitcoind-node -d \
+            -p 8333:8333 \
+            -p 127.0.0.1:8332:8332 \
+            -e DISABLEWALLET=1 \
+            -e PRINTTOCONSOLE=1 \
+            -e RPCUSER=mysecretrpcuser \
+            -e RPCPASSWORD=mysecretrpcpassword \
+            kylemanna/bitcoind
+
+Or you can use your very own config file like that:
+
+        docker run -v bitcoind-data:/bitcoin --name=bitcoind-node -d \
+            -p 8333:8333 \
+            -p 127.0.0.1:8332:8332 \
+            -v /etc/mybitcoin.conf:/bitcoin/.bitcoin/bitcoin.conf \
+            kylemanna/bitcoind

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,7 +3,7 @@ bitcoind config tuning
 
 You can use environment variables to customize config ([see docker run environment options](https://docs.docker.com/engine/reference/run/#/env-environment-variables)):
 
-        docker run -v bitcoind-data:/bitcoin --name=bitcoind-node -d \
+        docker run -v bitcoind-data:/bitcoin/.bitcoin --name=bitcoind-node -d \
             -p 8333:8333 \
             -p 127.0.0.1:8332:8332 \
             -e DISABLEWALLET=1 \
@@ -14,7 +14,7 @@ You can use environment variables to customize config ([see docker run environme
 
 Or you can use your very own config file like that:
 
-        docker run -v bitcoind-data:/bitcoin --name=bitcoind-node -d \
+        docker run -v bitcoind-data:/bitcoin/.bitcoin --name=bitcoind-node -d \
             -p 8333:8333 \
             -p 127.0.0.1:8332:8332 \
             -v /etc/mybitcoin.conf:/bitcoin/.bitcoin/bitcoin.conf \

--- a/init/docker-bitcoind.service
+++ b/init/docker-bitcoind.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Bitcoind Docker Container
 Documentation=https://github.com/kylemanna/docker-bitcoind
-After=network.target docker.socket
-Requires=docker.socket
+Requires=docker.service
+After=docker.service
 
 [Service]
 RestartSec=10


### PR DESCRIPTION
This PR returns `docker -bitcoind` to the state close to the upstream with the only changes for generating a configuration from en vars. 

if https://github.com/kylemanna/docker-bitcoind/pull/81 is merged, the docker image from the upstream can be used

 